### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Problem
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Steps to Reproduce the Problem
+
+1.
+
+2.
+
+3.
+
+## Specifications
+
+- Version:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Proposed Change
+
+Fixes:
+
+### How did you do this?
+
+### Why are you choosing this approach?
+
+### Any open questions you want to ask code reviewers?
+
+### List of changes:
+
+  -
+  -
+  -
+
+## Pull Request Checklist:
+
+  - [ ] I have referenced all useful information (issues, tasks, etc) in the pull request.


### PR DESCRIPTION
I figured because this is going to be an open source project it would be nice for you to have a template for issues and pull request descriptions for people to follow.

Let me know if you don't and I'll make changes!